### PR TITLE
PR for fixing tests for doctors

### DIFF
--- a/backend/src/main/kotlin/model/DoctorFactory.kt
+++ b/backend/src/main/kotlin/model/DoctorFactory.kt
@@ -47,3 +47,9 @@ fun newSimpleDoctor(name: String): NewDoctorAndUser {
 		)
 	);
 }
+
+fun resetDate(doctor: Doctor?): Doctor? {
+	val dateTime = LocalDateTime.of(2020, 5, 11, 0, 0, 0)
+	val doctorCopy = doctor?.copy(data = doctor?.data.copy(dateUpdated = dateTime))
+	return doctorCopy;
+}

--- a/backend/src/test/kotlin/domain/DoctorTest.kt
+++ b/backend/src/test/kotlin/domain/DoctorTest.kt
@@ -2,8 +2,10 @@ package domain
 
 import domain.Users.registerUser
 import kotlinx.coroutines.runBlocking
+import model.Doctor
 import model.newSimpleDoctor
 import model.newSimpleUserWithDoctorRole
+import model.resetDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import server.ServerTest
@@ -22,8 +24,12 @@ class DoctorTest : ServerTest() {
 		// then
 		val retrieved = Doctors.findById(saved.id)
 
-		assertThat(retrieved?.data).isEqualToIgnoringGivenFields(newDoctor.data, "dateUpdated")
-		assertThat(retrieved).isEqualToIgnoringGivenFields(saved, "data.dateUpdated")
+		val newDoctorCopy = resetDate(Doctor(saved.id, newDoctor.data, saved.user))
+		val savedCopy = resetDate(saved)
+		val retrievedCopy = resetDate(retrieved)
+
+		assertThat(retrievedCopy?.data).isEqualTo(newDoctorCopy?.data)
+		assertThat(retrievedCopy).isEqualTo(savedCopy)
 
 		Unit
 	}

--- a/backend/src/test/kotlin/web/DoctorApiTest.kt
+++ b/backend/src/test/kotlin/web/DoctorApiTest.kt
@@ -1,6 +1,8 @@
 package web
 
+import model.Doctor
 import model.newSimpleDoctor
+import model.resetDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import server.ServerTest
@@ -15,8 +17,12 @@ class DoctorApiTest : ServerTest() {
 	    // when
 	    val created = postDoctor(newDoctor)
 	    val retrieved = getDoctor(created.id)
-	    // then
-	    assertThat(created.data).isEqualToIgnoringGivenFields(newDoctor.doctor, "dateUpdated")
+
+		val newDoctorCopy = resetDate(Doctor(created.id, newDoctor.doctor, created.user))
+		val createdCopy = resetDate(created)
+
+		// then
+	    assertThat(createdCopy?.data).isEqualTo(newDoctorCopy?.data)
 	    assertThat(created.id).isEqualTo(retrieved.id)
     }
 


### PR DESCRIPTION
Added global method for creating new Doctor object with same data but changed dateUpdated to fixed value.

Changed tests to use new Doctors object with unchanged data except dateUpdated which is fixed to same value for each object.